### PR TITLE
Bugfix/uniq single arg fix

### DIFF
--- a/lib/array/uniq.js
+++ b/lib/array/uniq.js
@@ -16,7 +16,7 @@
         isObject       = require('../tester/isObject'),
         isString       = require('../tester/isString'),
         toArray        = require('../caster/toArray'),
-	isVoid	       = require('../tester/isVoid');
+        isVoid         = require('../tester/isVoid');
 
     /**
      * Creates a duplicate-value-free version of an array using `SameValueZero` for equality comparisons.
@@ -39,7 +39,7 @@
     module.exports = function uniq(array, iteratee, thisArg) {
         assertArgument(array = toArray(array), 1, 'Arrayable');
         assertArgument(isFunction(iteratee) || isObject(iteratee) || isString(iteratee) || isVoid(iteratee), 2, 'Function, Object or string');
-	if(isVoid(iteratee)) { iteratee = function(x) { return x; } };
+        if(isVoid(iteratee)) { iteratee = function(x) { return x; } };
         return _.uniq(array, iteratee, thisArg);
     };
 

--- a/lib/array/uniq.js
+++ b/lib/array/uniq.js
@@ -15,7 +15,8 @@
         isFunction     = require('../tester/isFunction'),
         isObject       = require('../tester/isObject'),
         isString       = require('../tester/isString'),
-        toArray        = require('../caster/toArray');
+        toArray        = require('../caster/toArray'),
+	isVoid	       = require('../tester/isVoid');
 
     /**
      * Creates a duplicate-value-free version of an array using `SameValueZero` for equality comparisons.
@@ -37,7 +38,8 @@
      */
     module.exports = function uniq(array, iteratee, thisArg) {
         assertArgument(array = toArray(array), 1, 'Arrayable');
-        assertArgument(isFunction(iteratee) || isObject(iteratee) || isString(iteratee), 2, 'Function, Object or string');
+        assertArgument(isFunction(iteratee) || isObject(iteratee) || isString(iteratee) || isVoid(iteratee), 2, 'Function, Object or string');
+	if(isVoid(iteratee)) { iteratee = function(x) { return x; } };
         return _.uniq(array, iteratee, thisArg);
     };
 


### PR DESCRIPTION
XP.uniq([1, 2, 3]) was not working because isVoid was missing from the second argument checklist
